### PR TITLE
fix: update `CODEOWNERS` groups

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
-# Engineers who are responsible for reviewing any take-homes
-* @reside-eng/TakeHomeReviewers
+* @reside-eng/TakeHomeAdministrators
+
+.github @reside-eng/Platform
 
 # Skip assigning dep updates (handled by Renovate)
 package.json

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @reside-eng/TakeHomeAdministrators
 
-.github @reside-eng/Platform
+/.github/ @reside-eng/Platform
 
 # Skip assigning dep updates (handled by Renovate)
-package.json
-yarn.lock
+/package.json
+/yarn.lock


### PR DESCRIPTION
## Changes

- Removed the now-deleted `TakeHomeReviewers` team.
- Assigned ownership of all repo files to `TakeHomeAdministrators`.
- Assigned ownership of GitHub files to `Platform`. 

## Admin Updates Needed

@hershmire, would you be able to make these changes 👇 ?

- [x] Grant write access for this repo to `@reside-eng/TakeHomeAdministrators`
- [x] Grant write access for this repo to `@reside-eng/Platform`